### PR TITLE
Fix lazyvoters reply to split message if length if larger than 2000

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,8 @@ sonar.organization=maintenance-of-votum-1
 
 sonar.coverage.exclusions=src/**/*.test.ts,src/__mocks__/*.ts
 
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=Votum
 #sonar.projectVersion=1.0

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -11,6 +11,8 @@ import Votum from "./Votum"
 
 export type ExtractRight<T> = T extends Either<infer L, infer R> ? R : never
 
+export const MAX_MESSAGE_SIZE = 2000
+
 export function withDefault<T extends t.Any>(
   type: T,
   defaultValue: t.TypeOf<T>

--- a/src/commands/Command.test.ts
+++ b/src/commands/Command.test.ts
@@ -53,13 +53,7 @@ describe("Command tests", () => {
       mockCommandoInfo
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user
-      } as unknown as CommandoMessage
-    )
+    const hasPermission = command.hasPermission(buildCommandMessage(user, undefined))
 
     expect(hasPermission).toBe(true)
   })
@@ -69,9 +63,10 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
           permissions: [Permissions.ALL]
@@ -81,13 +76,8 @@ describe("Command tests", () => {
           permissions: []
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-          roles: ['foo-role']
-        },
-      ],
-    })
+      ['foo-role']
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -97,15 +87,7 @@ describe("Command tests", () => {
       guild
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user,
-        member: member,
-      } as unknown as CommandoMessage
-    )
-
+    const hasPermission = command.hasPermission(buildCommandMessage(user, member))
     expect(hasPermission).toBe(true)
   })
 
@@ -114,9 +96,10 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
           permissions: []
@@ -127,13 +110,8 @@ describe("Command tests", () => {
           permissions: []
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-          roles: ['foo-role']
-        },
-      ],
-    })
+      ['foo-role']
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -143,15 +121,7 @@ describe("Command tests", () => {
       guild
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user,
-        member: member,
-      } as unknown as CommandoMessage
-    )
-
+    const hasPermission = command.hasPermission(buildCommandMessage(user, member))
     expect(hasPermission).toBe(true)
   })
 
@@ -160,20 +130,17 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
-          permissions: [],
+          permissions: []
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-        },
-      ],
-    })
+      []
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -182,15 +149,7 @@ describe("Command tests", () => {
       guild
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user,
-        member: member,
-      } as unknown as CommandoMessage
-    )
-
+    const hasPermission = command.hasPermission(buildCommandMessage(user, member))
     expect(hasPermission).toBe(false)
   })
 
@@ -202,9 +161,10 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
           permissions: []
@@ -215,13 +175,8 @@ describe("Command tests", () => {
           permissions: []
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-          roles: ['foo-role']
-        },
-      ],
-    })
+      ['foo-role']
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -231,15 +186,7 @@ describe("Command tests", () => {
       guild
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user,
-        member: member,
-      } as unknown as CommandoMessage
-    )
-
+    const hasPermission = command.hasPermission(buildCommandMessage(user, member))
     expect(hasPermission).toBe(true)
   })
 
@@ -254,25 +201,21 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
-          permissions: [],
+          permissions: []
         },
         {
           id: 'proposeRole',
           permissions: [],
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-          roles: ['proposeRole']
-        },
-      ],
-    })
+      ['proposeRole']
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -282,15 +225,7 @@ describe("Command tests", () => {
       guild
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user,
-        member: member,
-      } as unknown as CommandoMessage
-    )
-
+    const hasPermission = command.hasPermission(buildCommandMessage(user, member))
     expect(hasPermission).toBe(true)
   })
 
@@ -301,25 +236,21 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
-          permissions: [],
+          permissions: []
         },
         {
           id: 'councilorRole',
           permissions: [],
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-          roles: ['councilorRole']
-        },
-      ],
-    })
+      ['councilorRole']
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -329,15 +260,7 @@ describe("Command tests", () => {
       guild
     )
 
-    const hasPermission = command.hasPermission(
-      {
-        channel: { id: 10 },
-        reply: (msg: string) => {},
-        author: user,
-        member: member,
-      } as unknown as CommandoMessage
-    )
-
+    const hasPermission = command.hasPermission(buildCommandMessage(user, member))
     expect(hasPermission).toBe(true)
   })
 
@@ -346,20 +269,17 @@ describe("Command tests", () => {
       commandClient,
       mockCommandoInfo
     )
-    const guild = new Guild(commandClient, {
-      id: 123,
-      roles: [
+    const guild = buildGuild(
+      commandClient,
+      user,
+      [
         {
           id: 123,
-          permissions: [],
+          permissions: []
         }
       ],
-      members: [
-        {
-          user: { id: user.id, username: user.username },
-        },
-      ],
-    })
+      []
+    )
     const member = new GuildMember(
       commandClient,
       {
@@ -367,15 +287,30 @@ describe("Command tests", () => {
       },
       guild
     )
-    const commandMessage = {
-      channel: { id: 10 },
-      reply: (msg: string) => { return { content: msg } as Message },
-      author: user,
-      member: member,
-    } as unknown as CommandoMessage
 
-    const replyMessage = await command.run(commandMessage, {})
-
+    const replyMessage = await command.run(buildCommandMessage(user, member), {})
     expect(replyMessage).toStrictEqual( { content: "This command has no implementation." })
   })
 })
+
+function buildGuild(commandClient: CommandoClient, user: User, guildRoles: any, memberRoles: any) : Guild {
+  return new Guild(commandClient, {
+    id: 123,
+    roles: guildRoles,
+    members: [
+      {
+        user: { id: user.id, username: user.username },
+        roles: memberRoles
+      },
+    ],
+  })
+}
+
+function buildCommandMessage(user: User, member: GuildMember|undefined) : CommandoMessage {
+  return {
+    channel: { id: 10 },
+    reply: (msg: string) => { return { content: msg } as Message },
+    author: user,
+    member: member,
+  } as unknown as CommandoMessage
+}

--- a/src/commands/Command.test.ts
+++ b/src/commands/Command.test.ts
@@ -2,10 +2,8 @@ import { CommandoClient, CommandoMessage } from "discord.js-commando"
 import Command from './Command'
 //@ts-ignore
 import Votum from "../Votum"
-import { Guild, GuildMember, Permissions, User } from "discord.js"
-import { SnowflakeUtil } from "discord.js"
+import { Guild, GuildMember, Permissions, User, SnowflakeUtil, Message } from "discord.js"
 import { CouncilData } from "../CouncilData"
-import { Message } from "discord.js"
 
 const mockVotumInitialize = jest.fn()
 const mockVotumGetCouncil = jest
@@ -20,23 +18,23 @@ const mockVotumGetCouncil = jest
 jest.mock("../Votum", () => ({ getCouncil: () => mockVotumGetCouncil() }))
 
 describe("Command tests", () => {
-  var userId: string, user: User, commandClient: CommandoClient;
+  let userId: string, user: User, commandClient: CommandoClient, mockCommandoInfo: any
   beforeEach(() => {
     userId = SnowflakeUtil.generate()
     user = new User(new CommandoClient({ restSweepInterval: 0 }), {
       id: userId,
     })
     commandClient = new CommandoClient({ restSweepInterval: 0, owner: 'anotherOwner' })
-  })
-
-  test("Should create Command instance", () => {
-    const mockCommandoInfo = {
+    mockCommandoInfo = {
       description: "command",
       name: "test",
       councilOnly: false,
       adminOnly: true,
       adminsAlwaysAllowed: false,
     }
+  })
+
+  test("Should create Command instance", () => {
     const command = new Command(
       new CommandoClient({ restSweepInterval: 0 }),
       mockCommandoInfo
@@ -50,13 +48,7 @@ describe("Command tests", () => {
   })
 
   test("Should have permission if author user is owner", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: false,
-      adminsAlwaysAllowed: false,
-    }
+    mockCommandoInfo.adminOnly = false
 
     const command = new Command(
       new CommandoClient({ restSweepInterval: 0, owner: userId }),
@@ -75,14 +67,6 @@ describe("Command tests", () => {
   })
 
   test("Should have permission if author has permission to manage guild and command is admin only", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: true,
-      adminsAlwaysAllowed: false,
-    }
-
     const command = new Command(
       commandClient,
       mockCommandoInfo
@@ -128,14 +112,6 @@ describe("Command tests", () => {
   })
 
   test("Should have permission if author has admin role and command is admin only", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: true,
-      adminsAlwaysAllowed: false,
-    }
-
     const command = new Command(
       commandClient,
       mockCommandoInfo
@@ -182,14 +158,6 @@ describe("Command tests", () => {
   })
 
   test("Should not have permission if author is not admin and command is admin only", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: true,
-      adminsAlwaysAllowed: false,
-    }
-
     const command = new Command(
       commandClient,
       mockCommandoInfo
@@ -229,13 +197,8 @@ describe("Command tests", () => {
   })
 
   test("Should have permission if author is admin and admins are always allowed", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: false,
-      adminsAlwaysAllowed: true,
-    }
+    mockCommandoInfo.adminOnly = false
+    mockCommandoInfo.adminsAlwaysAllowed = true
 
     const command = new Command(
       commandClient,
@@ -283,12 +246,9 @@ describe("Command tests", () => {
   })
 
   test("Should have permission if author has role that is allowed in council", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
+    mockCommandoInfo = {
+      ...mockCommandoInfo,
       adminOnly: false,
-      adminsAlwaysAllowed: false,
       allowWithConfigurableRoles: ['proposeRole'] as Array<keyof CouncilData>
     }
 
@@ -337,13 +297,7 @@ describe("Command tests", () => {
   })
 
   test("Should have permission if council and author have councilor role", () => {
-    const mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: false,
-      adminsAlwaysAllowed: false,
-    }
+    mockCommandoInfo.adminOnly = false
 
     const command = new Command(
       commandClient,
@@ -390,14 +344,6 @@ describe("Command tests", () => {
   })
 
   test("Should run command", async () => {
-    var mockCommandoInfo = {
-      description: "command",
-      name: "test",
-      councilOnly: false,
-      adminOnly: true,
-      adminsAlwaysAllowed: false,
-    }
-
     const command = new Command(
       commandClient,
       mockCommandoInfo

--- a/src/commands/Command.test.ts
+++ b/src/commands/Command.test.ts
@@ -1,0 +1,437 @@
+import { CommandoClient, CommandoMessage } from "discord.js-commando"
+import Command from './Command'
+//@ts-ignore
+import Votum from "../Votum"
+import { Guild, GuildMember, Permissions, User } from "discord.js"
+import { SnowflakeUtil } from "discord.js"
+import { CouncilData } from "../CouncilData"
+import { Message } from "discord.js"
+
+const mockVotumInitialize = jest.fn()
+const mockVotumGetCouncil = jest
+  .fn()
+  .mockReturnValue({
+    active: true,
+    councilorRole: 'councilorRole',
+    initialize: () => mockVotumInitialize(),
+    getConfig: (config: any) => config
+  })
+
+jest.mock("../Votum", () => ({ getCouncil: () => mockVotumGetCouncil() }))
+
+describe("Command tests", () => {
+  var userId: string, user: User, commandClient: CommandoClient;
+  beforeEach(() => {
+    userId = SnowflakeUtil.generate()
+    user = new User(new CommandoClient({ restSweepInterval: 0 }), {
+      id: userId,
+    })
+    commandClient = new CommandoClient({ restSweepInterval: 0, owner: 'anotherOwner' })
+  })
+
+  test("Should create Command instance", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: true,
+      adminsAlwaysAllowed: false,
+    }
+    const command = new Command(
+      new CommandoClient({ restSweepInterval: 0 }),
+      mockCommandoInfo
+    )
+    expect(command.description).toBe("command")
+    expect(command.guildOnly).toBe(true)
+    expect(command.memberName).toBe("test")
+    expect(command.councilOnly).toBe(false)
+    expect(command.adminOnly).toBe(true)
+    expect(command.adminsAlwaysAllowed).toBe(false)
+  })
+
+  test("Should have permission if author user is owner", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: false,
+      adminsAlwaysAllowed: false,
+    }
+
+    const command = new Command(
+      new CommandoClient({ restSweepInterval: 0, owner: userId }),
+      mockCommandoInfo
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(true)
+  })
+
+  test("Should have permission if author has permission to manage guild and command is admin only", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: true,
+      adminsAlwaysAllowed: false,
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: [Permissions.ALL]
+        },
+        {
+          id: 'foo-role',
+          permissions: []
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+          roles: ['foo-role']
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+        roles: ['foo-role']
+      },
+      guild
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user,
+        member: member,
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(true)
+  })
+
+  test("Should have permission if author has admin role and command is admin only", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: true,
+      adminsAlwaysAllowed: false,
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: []
+        },
+        {
+          id: 'foo-role',
+          name: 'Votum Admin',
+          permissions: []
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+          roles: ['foo-role']
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+        roles: ['foo-role']
+      },
+      guild
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user,
+        member: member,
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(true)
+  })
+
+  test("Should not have permission if author is not admin and command is admin only", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: true,
+      adminsAlwaysAllowed: false,
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: [],
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+      },
+      guild
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user,
+        member: member,
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(false)
+  })
+
+  test("Should have permission if author is admin and admins are always allowed", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: false,
+      adminsAlwaysAllowed: true,
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: []
+        },
+        {
+          id: 'foo-role',
+          name: 'Votum Admin',
+          permissions: []
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+          roles: ['foo-role']
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+        roles: ['foo-role']
+      },
+      guild
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user,
+        member: member,
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(true)
+  })
+
+  test("Should have permission if author has role that is allowed in council", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: false,
+      adminsAlwaysAllowed: false,
+      allowWithConfigurableRoles: ['proposeRole'] as Array<keyof CouncilData>
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: [],
+        },
+        {
+          id: 'proposeRole',
+          permissions: [],
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+          roles: ['proposeRole']
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+        roles: ['proposeRole']
+      },
+      guild
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user,
+        member: member,
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(true)
+  })
+
+  test("Should have permission if council and author have councilor role", () => {
+    const mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: false,
+      adminsAlwaysAllowed: false,
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: [],
+        },
+        {
+          id: 'councilorRole',
+          permissions: [],
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+          roles: ['councilorRole']
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+        roles: ['councilorRole']
+      },
+      guild
+    )
+
+    const hasPermission = command.hasPermission(
+      {
+        channel: { id: 10 },
+        reply: (msg: string) => {},
+        author: user,
+        member: member,
+      } as unknown as CommandoMessage
+    )
+
+    expect(hasPermission).toBe(true)
+  })
+
+  test("Should run command", async () => {
+    var mockCommandoInfo = {
+      description: "command",
+      name: "test",
+      councilOnly: false,
+      adminOnly: true,
+      adminsAlwaysAllowed: false,
+    }
+
+    const command = new Command(
+      commandClient,
+      mockCommandoInfo
+    )
+    const guild = new Guild(commandClient, {
+      id: 123,
+      roles: [
+        {
+          id: 123,
+          permissions: [],
+        }
+      ],
+      members: [
+        {
+          user: { id: user.id, username: user.username },
+        },
+      ],
+    })
+    const member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+      },
+      guild
+    )
+    const commandMessage = {
+      channel: { id: 10 },
+      reply: (msg: string) => { return { content: msg } as Message },
+      author: user,
+      member: member,
+    } as unknown as CommandoMessage
+
+    const replyMessage = await command.run(commandMessage, {})
+
+    expect(replyMessage).toStrictEqual( { content: "This command has no implementation." })
+  })
+})

--- a/src/commands/Command.test.ts
+++ b/src/commands/Command.test.ts
@@ -1,9 +1,7 @@
 import { CommandoClient, CommandoMessage } from "discord.js-commando"
-import Command from './Command'
-//@ts-ignore
-import Votum from "../Votum"
 import { Guild, GuildMember, Permissions, User, SnowflakeUtil, Message } from "discord.js"
 import { CouncilData } from "../CouncilData"
+import Command from './Command'
 
 const mockVotumInitialize = jest.fn()
 const mockVotumGetCouncil = jest

--- a/src/commands/votum/PingInactiveCommand.test.ts
+++ b/src/commands/votum/PingInactiveCommand.test.ts
@@ -1,0 +1,121 @@
+import { CommandoClient, CommandoMessage } from "discord.js-commando"
+import PingInactiveCommand from "./PingInactiveCommand"
+//@ts-ignore
+import Votum from "../../Votum"
+//@ts-ignore
+import Motion from "../../Motion"
+import { Collection, Guild, GuildMember, Message, SnowflakeUtil, User } from "discord.js"
+
+const mockVotumInitialize = jest.fn()
+jest.mock("../../Motion", () => ({}))
+jest.mock('../../Util', () => ({
+  MAX_MESSAGE_SIZE: 70
+}))
+const mockCouncil = {
+  active: true,
+  councilorRole: "councilorRole",
+  initialize: () => mockVotumInitialize(),
+  getConfig: (config: any) => config,
+  currentMotion: null,
+}
+const mockCommandMessage = {
+  channel: { id: 10 },
+  reply: jest.fn((msg: string) => {
+    return { content: msg } as Message
+  }),
+  say: jest.fn((msg: string) => {
+    return { content: msg } as Message
+  }),
+}
+const mockGetCommandMessage = jest.fn().mockReturnValue(mockCommandMessage)
+const mockGetCouncil = jest.fn().mockReturnValue(mockCouncil)
+jest.mock("../../Votum", () => ({
+  getCouncil: () => mockGetCouncil(),
+}))
+
+describe("PingInactiveCommand tests", () => {
+  var commandClient: CommandoClient,
+    pingInactiveCommand: PingInactiveCommand,
+    user: User,
+    guild: Guild,
+    member: GuildMember,
+    commandMessage: CommandoMessage
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    commandClient = new CommandoClient({ restSweepInterval: 0 })
+    pingInactiveCommand = new PingInactiveCommand(commandClient)
+    user = new User(commandClient, {
+      id: SnowflakeUtil.generate(),
+    })
+    guild = new Guild(commandClient, {
+      id: SnowflakeUtil.generate()
+    })
+    member = new GuildMember(
+      commandClient,
+      {
+        user: { id: user.id, username: user.username },
+      },
+      guild
+    )
+    commandMessage = mockGetCommandMessage()
+  })
+
+  test("Should create PingInactiveCommand instance", () => {
+    expect(pingInactiveCommand.name).toBe("pinginactive")
+    expect(pingInactiveCommand.aliases).toContain("pingremaining")
+    expect(pingInactiveCommand.aliases).toContain("mentionremaining")
+    expect(pingInactiveCommand.aliases).toContain("alertothers")
+    expect(pingInactiveCommand.aliases).toContain("lazyvoters")
+    expect(pingInactiveCommand.description).toBe(
+      "Mention the remaining councilmembers who haven't voted yet."
+    )
+    expect(pingInactiveCommand.adminsAlwaysAllowed).toBe(true)
+  })
+
+  test("Should not execute if there is no motion active", async () => {
+    mockGetCouncil.mockReturnValue({...mockCouncil})
+    const commandResult = await pingInactiveCommand.run(commandMessage, {})
+    expect(commandResult).toStrictEqual({
+      content: "There is no motion active.",
+    })
+  })
+
+  test("Should send only one reply if smaller than max message size", async () => {
+    const remainingVotersList = new Collection<string, GuildMember>()
+    remainingVotersList.set('voter1', member);
+    mockGetCouncil.mockReturnValue({
+      ...mockCouncil,
+      currentMotion: { getRemainingVoters: () => remainingVotersList},
+    })
+
+    const commandResult = await pingInactiveCommand.run(commandMessage, {})
+
+    expect(commandResult).toStrictEqual({
+      content: `These councilors still need to vote:\n\n${member}`,
+    })
+    expect(commandMessage.say).toHaveBeenCalledTimes(0);
+    expect(commandMessage.reply).toHaveBeenCalledTimes(1);
+  })
+
+  test("Should divide text in multiple replies if bigger than max message size", async () => {
+    const remainingVotersList = new Collection<string, GuildMember>()
+    remainingVotersList.set('voter1', member)
+    remainingVotersList.set('voter2', member);
+    remainingVotersList.set('voter3', member);
+    remainingVotersList.set('voter4', member);
+    remainingVotersList.set('voter5', member);
+    mockGetCouncil.mockReturnValue({
+      ...mockCouncil,
+      currentMotion: { getRemainingVoters: () => remainingVotersList},
+    })
+
+    const commandResult = await pingInactiveCommand.run(commandMessage, {})
+
+    expect(commandResult).toStrictEqual({
+      content: `${member}`,
+    }) 
+    expect(commandMessage.say).toHaveBeenCalledTimes(2);
+    expect(commandMessage.reply).toHaveBeenCalledTimes(1);
+  })
+})

--- a/src/commands/votum/PingInactiveCommand.test.ts
+++ b/src/commands/votum/PingInactiveCommand.test.ts
@@ -1,9 +1,5 @@
 import { CommandoClient, CommandoMessage } from "discord.js-commando"
 import PingInactiveCommand from "./PingInactiveCommand"
-//@ts-ignore
-import Votum from "../../Votum"
-//@ts-ignore
-import Motion from "../../Motion"
 import { Collection, Guild, GuildMember, Message, SnowflakeUtil, User } from "discord.js"
 
 const mockVotumInitialize = jest.fn()
@@ -34,7 +30,7 @@ jest.mock("../../Votum", () => ({
 }))
 
 describe("PingInactiveCommand tests", () => {
-  var commandClient: CommandoClient,
+  let commandClient: CommandoClient,
     pingInactiveCommand: PingInactiveCommand,
     user: User,
     guild: Guild,

--- a/src/commands/votum/PingInactiveCommand.ts
+++ b/src/commands/votum/PingInactiveCommand.ts
@@ -1,6 +1,7 @@
 import { Message } from "discord.js"
 import { CommandoClient, CommandoMessage } from "discord.js-commando"
 import Command from "../Command"
+import { MAX_MESSAGE_SIZE } from "../../Util"
 
 export default class PingInactiveCommand extends Command {
   constructor(client: CommandoClient) {
@@ -14,7 +15,7 @@ export default class PingInactiveCommand extends Command {
       ],
       description:
         "Mention the remaining councilmembers who haven't voted yet.",
-      adminsAlwaysAllowed: true
+      adminsAlwaysAllowed: true,
     })
   }
 
@@ -23,9 +24,31 @@ export default class PingInactiveCommand extends Command {
       return msg.reply("There is no motion active.")
     }
 
-    return msg.reply(
-      "These councilors still need to vote:\n\n" +
-        this.council.currentMotion.getRemainingVoters().array().join(" ")
-    )
+    const messageReply = "These councilors still need to vote:\n\n"
+    const remainingVoters = this.council.currentMotion.getRemainingVoters().array().join(" ")
+    const messageTotalLength = messageReply.length + remainingVoters.length
+
+    if (messageTotalLength > MAX_MESSAGE_SIZE) {
+      let remainingVotersNotSent = remainingVoters
+      let firstIteration = true
+
+      do {
+        const maxRemainingVotersMsgSize = firstIteration ? (MAX_MESSAGE_SIZE - messageReply.length) : MAX_MESSAGE_SIZE
+        const lastVoterSeparatorIndex = remainingVotersNotSent.substring(0, maxRemainingVotersMsgSize).lastIndexOf(" ")
+        const votersMessageContent = remainingVotersNotSent.substring(0, lastVoterSeparatorIndex)
+        if (firstIteration) {
+          firstIteration = false
+          await msg.reply(messageReply + votersMessageContent)
+        } else {
+          await msg.say(votersMessageContent)
+        }
+
+        remainingVotersNotSent = remainingVotersNotSent.substring(lastVoterSeparatorIndex + 1, remainingVotersNotSent.length)
+      } while (remainingVotersNotSent.length > MAX_MESSAGE_SIZE)
+
+      return msg.say(remainingVotersNotSent)
+    } else {
+      return msg.reply(messageReply + remainingVoters)
+    }
   }
 }


### PR DESCRIPTION
Corrige bug em que mensagem de erro "An error occurred while running the command: DiscordAPIError: Invalid Form Body content: Must be 2000 or fewer in length." é apresentada caso mensagem de resposta ao comando !lazyvoters é maior que o tamanho limite de mensagens do Discord (2000 caracteres).

Caso tamanho da mensagem seja menor que tamanho máximo, envia mensagem da mesma forma que antes.
Caso contrário, resposta é quebrada em múltiplas mensagens de no máximo 2000 caracteres, atentando-se para respeitar os separadores dos IDs dos usuários votantes e não quebrar estes IDs no meio.