### PR TITLE
feat(sonar): collect test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install dependencies
+        run: npm install
+      - name: Test and coverage
+        run: npm test -- --coverage
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.3",
         "discord.js": "^12.5.1",
-        "discord.js-commando": "git+https://github.com/discordjs/Commando.git#198d7604e3725ee88dceab9b5f296edb1b7580a5",
+        "discord.js-commando": "0.11.1",
         "dotenv": "^5.0.1",
         "fp-ts": "^1.14.4",
         "io-ts": "^1.8.2",
-        "minimist": "^1.2.3",
+        "minimist": "^1.2.6",
         "num2fraction": "^1.2.2",
         "on-change": "^0.1.0"
       },
@@ -1452,14 +1452,18 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2139,23 +2143,22 @@
       }
     },
     "node_modules/discord.js-commando": {
-      "version": "0.11.0-dev",
-      "resolved": "git+ssh://git@github.com/discordjs/Commando.git#198d7604e3725ee88dceab9b5f296edb1b7580a5",
-      "integrity": "sha512-FeHYL/7LARFZZqgLPoAmqqNGD3jU1eNvSusWESjHPpeJT1rZ6Phx5A3vCPpik/CN6UOJRCyI8dJ2m5z0vpquNA==",
-      "license": "Apache-2.0",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/discord.js-commando/-/discord.js-commando-0.11.1.tgz",
+      "integrity": "sha512-wjx29ur6Z94mmTvCvPT0YJYjt4v6PzHj4FtVWJdMYWzm15MuWNgdU3sqRrGK0bXAFfv1H8faDBUdNGrxRPQnmA==",
       "dependencies": {
         "common-tags": "^1.8.0",
+        "emoji-regex": "^9.2.0",
         "require-all": "^3.0.0"
       },
       "engines": {
         "node": ">=8.6.0"
-      },
-      "peerDependencies": {
-        "@types/better-sqlite3": "^5.0.0",
-        "better-sqlite3": "^5.0.0",
-        "discord.js": "^12.0.0",
-        "sqlite": "^3.0.0"
       }
+    },
+    "node_modules/discord.js-commando/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/doctrine": {
       "version": "0.7.2",
@@ -2394,9 +2397,9 @@
       }
     },
     "node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -4698,12 +4701,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json5/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4864,9 +4861,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
-      "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.1",
@@ -7383,9 +7383,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7930,12 +7930,20 @@
       }
     },
     "discord.js-commando": {
-      "version": "git+ssh://git@github.com/discordjs/Commando.git#198d7604e3725ee88dceab9b5f296edb1b7580a5",
-      "integrity": "sha512-FeHYL/7LARFZZqgLPoAmqqNGD3jU1eNvSusWESjHPpeJT1rZ6Phx5A3vCPpik/CN6UOJRCyI8dJ2m5z0vpquNA==",
-      "from": "discord.js-commando@git+https://github.com/discordjs/Commando.git#198d7604e3725ee88dceab9b5f296edb1b7580a5",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/discord.js-commando/-/discord.js-commando-0.11.1.tgz",
+      "integrity": "sha512-wjx29ur6Z94mmTvCvPT0YJYjt4v6PzHj4FtVWJdMYWzm15MuWNgdU3sqRrGK0bXAFfv1H8faDBUdNGrxRPQnmA==",
       "requires": {
         "common-tags": "^1.8.0",
+        "emoji-regex": "^9.2.0",
         "require-all": "^3.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        }
       }
     },
     "doctrine": {
@@ -9843,14 +9851,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "kleur": {
@@ -9976,9 +9976,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -10180,9 +10180,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "pause-stream": {
@@ -10629,9 +10629,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-fast-properties": {
@@ -10820,9 +10820,9 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "ajv": "^6.12.3",
     "discord.js": "^12.5.1",
-    "discord.js-commando": "git+https://github.com/discordjs/Commando.git#198d7604e3725ee88dceab9b5f296edb1b7580a5",
+    "discord.js-commando": "0.11.1",
     "dotenv": "^5.0.1",
     "fp-ts": "^1.14.4",
     "io-ts": "^1.8.2",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,9 @@
 sonar.projectKey=maintenance-of-votum:123
 sonar.organization=maintenance-of-votum
 
+# To collect test coverage
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=Maintenance of Votum
 #sonar.projectVersion=1.0

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -52,7 +52,9 @@ export default class Command extends Commando.Command {
     }
 
     const isAdmin =
+      // @ts-ignore
       msg.member.hasPermission("MANAGE_GUILD") ||
+      // @ts-ignore
       !!msg.member.roles.cache.find((role) => role.name === "Votum Admin")
 
     if (this.adminOnly) {
@@ -65,11 +67,13 @@ export default class Command extends Commando.Command {
       this.customInfo.allowWithConfigurableRoles.find(
         (configName) =>
           council.getConfig(configName) &&
+          // @ts-ignore
           msg.member.roles.cache.has(council.getConfig(configName) as string)
       )
     ) {
       return true
     } else if (council.councilorRole != null) {
+      // @ts-ignore
       return msg.member.roles.cache.has(council.councilorRole)
     }
 

--- a/src/commands/abstract/VoteAliasCommand.ts
+++ b/src/commands/abstract/VoteAliasCommand.ts
@@ -21,6 +21,7 @@ export default class VoteAliasCommand extends Command {
 
     if (
       !args.reason &&
+      // @ts-ignore
       this.council.getConfig(reasonRequiredMap[msg.command.name])
     ) {
       return msg.reply("You must provide a reason with your vote.")
@@ -36,12 +37,14 @@ export default class VoteAliasCommand extends Command {
 
     const voteStatus = motion.castVote({
       authorId: msg.author.id,
+      // @ts-ignore
       authorName: msg.member.displayName,
       name: this.getVoteName(msg),
       state: this.state,
       reason: args.reason,
       isDictator: this.council.getConfig("dictatorRole")
-        ? msg.member.roles.cache.has(this.council.getConfig("dictatorRole")!)
+        ? // @ts-ignore
+          msg.member.roles.cache.has(this.council.getConfig("dictatorRole")!)
         : false,
     })
 
@@ -58,6 +61,7 @@ export default class VoteAliasCommand extends Command {
   }
 
   private getVoteName(msg: CommandoMessage) {
+    // @ts-ignore
     let name = msg.command.name
 
     if (msg.cleanContent.substring(0, 1) === Votum.bot.commandPrefix) {

--- a/src/commands/votum/MotionCommand.ts
+++ b/src/commands/votum/MotionCommand.ts
@@ -27,6 +27,7 @@ export default class MotionCommand extends Command {
   }
 
   async execute(msg: CommandoMessage, args: any): Promise<Message | Message[]> {
+    // @ts-ignore
     await msg.guild.members.fetch() // Privileged intents fix
 
     if (!args.text) {
@@ -43,7 +44,9 @@ export default class MotionCommand extends Command {
       if (args.text === "kill") {
         if (
           this.council.currentMotion.authorId === msg.author.id ||
+          // @ts-ignore
           msg.member.hasPermission("MANAGE_GUILD") ||
+          // @ts-ignore
           !!msg.member.roles.cache.find((role) => role.name === "Votum Admin")
         ) {
           const motion = this.council.currentMotion
@@ -68,6 +71,7 @@ export default class MotionCommand extends Command {
     }
 
     const proposeRole = this.council.getConfig("proposeRole")
+    // @ts-ignore
     if (proposeRole && !msg.member.roles.cache.has(proposeRole)) {
       return msg.reply("You don't have permission to propose motions.")
     }
@@ -121,6 +125,7 @@ export default class MotionCommand extends Command {
     const motion = this.council.createMotion({
       text,
       authorId: msg.author.id,
+      // @ts-ignore
       authorName: msg.member.displayName,
       createdAt: Date.now(),
       voteType,

--- a/src/commands/votum/SetWeight.ts
+++ b/src/commands/votum/SetWeight.ts
@@ -47,10 +47,12 @@ export default class SetWeightCommand extends Command {
 
     const lines = []
     for (const [id, weight] of Object.entries(weights)) {
+      // @ts-ignore
       const maybeRole = await msg.guild.roles.fetch(id)
       const maybeUser = maybeRole
         ? null
-        : await msg.guild.members.fetch(id).catch(() => null)
+        : // @ts-ignore
+          await msg.guild.members.fetch(id).catch(() => null)
 
       if (maybeRole) {
         lines.push(`[Role] ${maybeRole.name} : ${weight}`)

--- a/src/commands/votum/StatsCommand.ts
+++ b/src/commands/votum/StatsCommand.ts
@@ -51,6 +51,7 @@ export default class StatsCommand extends Command {
   }
 
   async execute(msg: CommandoMessage, args: any): Promise<Message | Message[]> {
+    // @ts-ignore
     await msg.guild.members.fetch() // Privileged intents fix
     const lastVoted: { [index: string]: number } = {}
     const lastMotion: { [index: string]: number } = {}


### PR DESCRIPTION
This Pull Request:
* Updates `discord.js-commando` to v0.11.1.
   * It was needed since the instalation of the fixed commit version is broken in Linux
* Adds `//@ts-ignore` in lines that now shws TS errors after the `discord.js-commando` update
   * In a normal scenario this is not the right thing to do, but since we'll have to update d.js I think its ok for now
* Runs tests in each Pull Request and merge to master, and send coverage to SonarCloud

Closes #17 