### PR TITLE
Test/Motion

### DIFF
--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -63,8 +63,28 @@ test("Test motion majorities", () => {
     foo.options = {majority: 1}
     expect(motion.requiredMajority).toBe(1)
 })
-
+describe("Test getReadableMajorities", () => {
+    test("Test getReadableMajorities return Unanimous", () => {
+        //@ts-ignore
+        const motion = new Motion(0, foo, {
+            getConfig: jest.fn().mockReturnValue(1),
+        })
+        expect(motion.getReadableMajority()).toBe("Unanimous")
+    })
+    test("Test getReadableMajorities return Simple Majority", () => {
+        //@ts-ignore
+        const motion = new Motion(0, foo, {
+            getConfig: jest.fn().mockReturnValue(0.5),
+        })
+        expect(motion.getReadableMajority()).toBe("Simple majority")
+    })
+    test("Test getReadableMajorities return default value", () => {
+        //@ts-ignore
+        const motion = new Motion(0, foo, {
+            getConfig: jest.fn().mockReturnValue("s"),
+        })
+        expect(motion.getReadableMajority()).toBe("1/2")
+    })
 })
 
-    //return null/undefined on the first //
-    //mock return values
+})

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -88,15 +88,45 @@ describe("Test getReadableMajorities", () => {
         expect(motion.getReadableMajority()).toBe("3/4")
     })
 })
-test("Test Resolve", () => {
+describe("Test Resolve", () => {
     //@ts-ignore
     const motion = new Motion(0, foo, getCouncil())
-    //@ts-ignore
-    expect(() => {motion.resolve({})}).toThrow(Error)
+    test("Test Attempt to resolve a resolved motion error", () => {
+        //@ts-ignore
+        expect(() => {motion.resolve({})}).toThrow(Error)
+    })
+    test("Test data is active", () => {
+        foo.active = true
+        //@ts-ignore
+        expect(motion.resolve({})).toBe(undefined)
+        expect(foo.active).toBe(false)
+        expect(foo.resolution).toBe(foo.resolution)
+        expect(foo.didExpire).toBe(false)
+    })
 
-    foo.active = true
-    //@ts-ignore
-    expect(motion.resolve({})).toBe(undefined)
+    test("Test MotionResolution Failed", () =>{
+        foo.active = true
+        motion.council.setConfig("onFailedAnnounce", "foo")
+        const motionResolve = MotionResolution.Failed
+        motion.resolve(motionResolve)
+        expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
+    })
+
+    test("Test MotionResolution Passed", () =>{
+        foo.active = true
+        motion.council.setConfig("onPassedAnnounce", "foo")
+        const motionResolve = MotionResolution.Passed
+        motion.resolve(motionResolve)
+        expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
+    })
+
+    test("Test MotionResolution Killed", () =>{
+        foo.active = true
+        motion.council.setConfig("onKilledAnnounce", "foo")
+        const motionResolve = MotionResolution.Killed
+        motion.resolve(motionResolve)
+        expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
+    })
 })
 
 })

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -158,4 +158,18 @@ describe("Test Resolve", () => {
     })
 })
 
+describe("Test motion votes", () =>{
+    //@ts-ignore
+    const motion = new Motion(0, foo, getCouncil())
+    test("Test getVotes", () =>{
+        const votes = motion.getVotes()
+        expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 0})
+    })
+    test("Test castVote", () =>{
+        expect(1).toBe(1)
+    })
+    test("Test getRemainingVoters", () =>{
+        expect(1).toBe(1)
+    })
+})
 })

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -1,0 +1,51 @@
+import Motion from "./Motion"
+// @ts-ignore
+import Votum from "./Votum"
+import { promises as fs } from "fs"
+import path from "path"
+import { MotionData } from "./MotionData"
+import { MotionResolution } from "./Motion"
+
+jest.mock("./Votum", () => jest.fn().mockImplementation(() => ({})))
+
+const clearDataFolder = async () => {
+  // https://stackoverflow.com/a/42182416/13152732
+  const directory = `${__dirname}/../data`
+
+  for (const file of await fs.readdir(directory)) {
+    if (file.match(/test-/)) await fs.unlink(path.join(directory, file))
+  }
+}
+
+describe("Motion Class Test", () => {
+    afterEach(async() => {
+        await clearDataFolder()
+    })
+    afterAll(async() => {
+        await clearDataFolder()
+    })
+test("Should start a motion correctly", () => {
+    const foo: MotionData = {
+        authorId: "",
+        authorName: "",
+        active: false,
+        resolution: MotionResolution.Unresolved,
+        text: "",
+        createdAt: 0,
+        didExpire: false,
+        votes: []
+    }
+    //@ts-ignore
+    const motion = new Motion(0, foo, {})
+
+    expect(motion.authorId).toBe("")
+    expect(motion.authorName).toBe("")
+    expect(motion.number).toBe(1)
+    //is expired
+    expect(motion.votes).toStrictEqual([])
+    expect(motion.createdAt).toBe(0)
+    expect(motion.text).toBe("")
+    expect(motion.resolution).toBe(MotionResolution.Unresolved)
+    //requiredMajority
+    expect(Object.is(motion.getData, foo))
+})})

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -1,10 +1,9 @@
-import Motion from "./Motion"
 // @ts-ignore
 import Votum from "./Votum"
+import Motion, { MotionResolution } from "./Motion"
 import { promises as fs } from "fs"
 import path from "path"
 import { MotionData } from "./MotionData"
-import { MotionResolution } from "./Motion"
 import { getCouncil } from "./__mocks__/council"
 import {
   OnFinishActions,
@@ -17,7 +16,7 @@ const clearDataFolder = async () => {
   const directory = `${__dirname}/../data`
 
   for (const file of await fs.readdir(directory)) {
-    if (file.match(/test-/)) await fs.unlink(path.join(directory, file))
+    if (/test-/.exec(file)) await fs.unlink(path.join(directory, file))
   }
 }
 
@@ -146,7 +145,7 @@ describe("Test Resolve", () => {
         expect(motionData.active).toBe(false)
     })
     
-    var actions: OnFinishActions = {}
+    let actions: OnFinishActions = {}
     motionData.resolution = MotionResolution.Failed
     motion.council.setConfig("onFailedAnnounce", "foo")
 
@@ -229,9 +228,9 @@ describe("Test motion votes", () =>{
         expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 0})
     })
     test("Test getRemainingVoters", () =>{
-        var remainingVoters = motion.getRemainingVoters()
+        let remainingVoters = motion.getRemainingVoters()
         //users from the council mock that have not voted
-        var expected = [
+        let expected = [
             {
                 "deleted": false, 
                 "displayName": "votum-app",

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -103,21 +103,25 @@ describe("Test Resolve", () => {
         expect(foo.resolution).toBe(foo.resolution)
         expect(foo.didExpire).toBe(false)
     })
-
+    
+    //mock post message to test it on another set of tests
+    motion.postMessage = jest.fn()
+    
     test("Test MotionResolution Failed", () =>{
         foo.active = true
         motion.council.setConfig("onFailedAnnounce", "foo")
         const motionResolve = MotionResolution.Failed
         motion.resolve(motionResolve)
         expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
+        expect(foo.active).toBe(false)
     })
-
     test("Test MotionResolution Passed", () =>{
         foo.active = true
         motion.council.setConfig("onPassedAnnounce", "foo")
         const motionResolve = MotionResolution.Passed
         motion.resolve(motionResolve)
         expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
+        expect(foo.active).toBe(false)
     })
 
     test("Test MotionResolution Killed", () =>{
@@ -126,6 +130,31 @@ describe("Test Resolve", () => {
         const motionResolve = MotionResolution.Killed
         motion.resolve(motionResolve)
         expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
+        expect(foo.active).toBe(false)
+    })
+
+    test("Test actions", () =>{
+        foo.active = true
+        motion.council.setConfig("onFinishActions", "forward")
+        motion.council.setConfig("onFailedAnnounce", "foo")
+        var motionResolve = MotionResolution.Failed
+        motion.resolve(motionResolve)
+
+        foo.active = true
+        motion.council.setConfig("onFinishActions", "forward")
+        motion.council.setConfig("onPassedAnnounce", "foo")
+        motionResolve = MotionResolution.Passed
+        motion.resolve(motionResolve)
+
+        foo.deliberationChannelId = "s"
+        motion.council.setConfig("keepTranscripts", true)
+        foo.active = true
+        motion.council.setConfig("onFinishActions", "forward")
+        motion.council.setConfig("onKilledAnnounce", "foo")
+        motionResolve = MotionResolution.Killed
+        motion.resolve(motionResolve)
+        expect(foo.active).toBe(false)
+        expect(foo.deliberationChannelId).toBe("s")
     })
 })
 

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -6,8 +6,11 @@ import path from "path"
 import { MotionData } from "./MotionData"
 import { MotionResolution } from "./Motion"
 import { getCouncil } from "./__mocks__/council"
+import {
+  OnFinishActions,
+} from "./CouncilData"
 
-jest.mock("./Votum", () => jest.fn().mockImplementation(() => ({})))
+jest.mock("./Votum", () => ({getCouncil: jest.fn().mockReturnValue({})}))
 
 const clearDataFolder = async () => {
   // https://stackoverflow.com/a/42182416/13152732
@@ -154,7 +157,16 @@ describe("Test Resolve", () => {
         foo.deliberationChannelId = "s"
         motion.council.setConfig("keepTranscripts", true)
         foo.active = true
-        motion.council.setConfig("onFinishActions", {failed: false, passed: false, killed: true})
+
+        const actions: OnFinishActions = {
+          killed: [
+            {
+              action: "forward",
+              to: "foo",
+            },
+          ],
+        }
+        motion.council.setConfig("onFinishActions", actions)
         motion.council.setConfig("onKilledAnnounce", "foo")
         motionResolve = MotionResolution.Killed
         motion.resolve(motionResolve)

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "fs"
 import path from "path"
 import { MotionData } from "./MotionData"
 import { MotionResolution } from "./Motion"
+import { getCouncil } from "./__mocks__/council"
 
 jest.mock("./Votum", () => jest.fn().mockImplementation(() => ({})))
 
@@ -62,6 +63,7 @@ test("Test motion majorities", () => {
     expect(motion.requiredMajority).toBe(0.5)
     foo.options = {majority: 1}
     expect(motion.requiredMajority).toBe(1)
+    foo.options = undefined
 })
 describe("Test getReadableMajorities", () => {
     test("Test getReadableMajorities return Unanimous", () => {
@@ -78,13 +80,23 @@ describe("Test getReadableMajorities", () => {
         })
         expect(motion.getReadableMajority()).toBe("Simple majority")
     })
-    test("Test getReadableMajorities return default value", () => {
+    test("Test getReadableMajorities return fraction of value", () => {
         //@ts-ignore
         const motion = new Motion(0, foo, {
-            getConfig: jest.fn().mockReturnValue("s"),
+            getConfig: jest.fn().mockReturnValue("0.75"),
         })
-        expect(motion.getReadableMajority()).toBe("1/2")
+        expect(motion.getReadableMajority()).toBe("3/4")
     })
+})
+test("Test Resolve", () => {
+    //@ts-ignore
+    const motion = new Motion(0, foo, getCouncil())
+    //@ts-ignore
+    expect(() => {motion.resolve({})}).toThrow(Error)
+
+    foo.active = true
+    //@ts-ignore
+    expect(motion.resolve({})).toBe(undefined)
 })
 
 })

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -24,7 +24,6 @@ describe("Motion Class Test", () => {
     afterAll(async() => {
         await clearDataFolder()
     })
-test("Should start a motion correctly", () => {
     const foo: MotionData = {
         authorId: "",
         authorName: "",
@@ -33,19 +32,39 @@ test("Should start a motion correctly", () => {
         text: "",
         createdAt: 0,
         didExpire: false,
-        votes: []
+        votes: [],
     }
+test("Should start a motion correctly", () => {
     //@ts-ignore
-    const motion = new Motion(0, foo, {})
-
+    const motion = new Motion(0, foo, {
+        //getConfig: () => 0.75
+        motionExpiration: 0
+    })
     expect(motion.authorId).toBe("")
     expect(motion.authorName).toBe("")
     expect(motion.number).toBe(1)
-    //is expired
+    expect(motion.isExpired).toBe(false)
     expect(motion.votes).toStrictEqual([])
     expect(motion.createdAt).toBe(0)
+    motion.createdAt = 1
+    expect(motion.createdAt).toBe(1)
     expect(motion.text).toBe("")
     expect(motion.resolution).toBe(MotionResolution.Unresolved)
-    //requiredMajority
-    expect(Object.is(motion.getData, foo))
-})})
+    expect(Object.is(motion.getData(), foo))
+})
+test("Test motion majorities", () => {
+    //@ts-ignore
+    const motion = new Motion(0, foo, {
+        //getConfig: () => 0.75
+        getConfig: jest.fn().mockReturnValueOnce(0.75).mockReturnValue(undefined),
+    })
+    expect(motion.requiredMajority).toBe(0.75)
+    expect(motion.requiredMajority).toBe(0.5)
+    foo.options = {majority: 1}
+    expect(motion.requiredMajority).toBe(1)
+})
+
+})
+
+    //return null/undefined on the first //
+    //mock return values

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -218,9 +218,9 @@ describe("Test motion votes", () =>{
         expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 0})
     })
     test("Test getRemainingVoters", () =>{
-        const remainingVoters = motion.getRemainingVoters()
+        var remainingVoters = motion.getRemainingVoters()
         //users from the council mock that have not voted
-        const expected = [
+        var expected = [
             {
                 "deleted": false, 
                 "displayName": "votum-app",
@@ -251,6 +251,40 @@ describe("Test motion votes", () =>{
                 "premiumSinceTimestamp": null, 
                 "userID": "bar"
             }]
+        expect(remainingVoters.toJSON()).toStrictEqual(expected)
+        
+        motion.castVote({
+            authorId: "foo",
+            authorName: "user-foo",
+            state: 1,
+            name: "user-foo",
+            reason: "foo",
+            isDictator: false,
+        })
+
+        expected = [
+            {
+                "deleted": false, 
+                "displayName": "votum-app",
+                "guildID": 123, 
+                "joinedTimestamp": null, 
+                "lastMessageChannelID": null, 
+                "nickname": null, 
+                "premiumSinceTimestamp": null, 
+                "userID": "votum"
+            },
+            {
+                "deleted": false, 
+                "displayName": "user-bar", 
+                "guildID": 123, 
+                "joinedTimestamp": null, 
+                "lastMessageChannelID": null, 
+                "nickname": null, 
+                "premiumSinceTimestamp": null, 
+                "userID": "bar"
+            }]
+
+        remainingVoters = motion.getRemainingVoters()
         expect(remainingVoters.toJSON()).toStrictEqual(expected)
     })
     test("Test castVote", () =>{

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -113,16 +113,16 @@ describe("Test Resolve", () => {
     test("Test MotionResolution Failed", () =>{
         foo.active = true
         motion.council.setConfig("onFailedAnnounce", "foo")
-        const motionResolve = MotionResolution.Failed
-        motion.resolve(motionResolve)
+        foo.resolution = MotionResolution.Failed
+        motion.resolve(foo.resolution)
         expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
         expect(foo.active).toBe(false)
     })
     test("Test MotionResolution Passed", () =>{
         foo.active = true
         motion.council.setConfig("onPassedAnnounce", "foo")
-        const motionResolve = MotionResolution.Passed
-        motion.resolve(motionResolve)
+        foo.resolution = MotionResolution.Passed
+        motion.resolve(foo.resolution)
         expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
         expect(foo.active).toBe(false)
     })
@@ -130,35 +130,70 @@ describe("Test Resolve", () => {
     test("Test MotionResolution Killed", () =>{
         foo.active = true
         motion.council.setConfig("onKilledAnnounce", "foo")
-        const motionResolve = MotionResolution.Killed
-        motion.resolve(motionResolve)
+        foo.resolution = MotionResolution.Killed
+        motion.resolve(foo.resolution)
         expect(motion.council.isUserOnCooldown(foo.authorId)).toBe(false)
         expect(foo.active).toBe(false)
     })
 
     test("Test actions", () =>{
+        var actions: OnFinishActions = {}
+        motion.council.setConfig("onFinishActions", actions)
+        foo.resolution = MotionResolution.Failed
         foo.active = true
-        motion.council.setConfig("onFinishActions", 
-        {
-            failed: [{action: "forward", atMajority: 1, options: undefined, to: 123}], 
-            passed: false, 
-            killed: false
-        })
         motion.council.setConfig("onFailedAnnounce", "foo")
-        var motionResolve = MotionResolution.Failed
-        motion.resolve(motionResolve)
-
+        motion.resolve(foo.resolution)
+        expect(foo.active).toBe(false)
+        expect(foo.didExpire).toBe(motion.isExpired)
+        
+        //Finish actions for failed
+        actions = {
+            failed: [
+                {
+                    action: "forward",
+                    to: "foo",
+                }
+            ]
+        }
         foo.active = true
-        motion.council.setConfig("onFinishActions", {failed: false, passed: true, killed: false})
-        motion.council.setConfig("onPassedAnnounce", "foo")
-        motionResolve = MotionResolution.Passed
-        motion.resolve(motionResolve)
+        motion.council.setConfig("onFinishActions", actions)
+        motion.resolve(foo.resolution)
+        expect(foo.active).toBe(false)
+        expect(foo.didExpire).toBe(motion.isExpired)
+        
+        //Finish actions for passed
+        foo.resolution = MotionResolution.Passed
+        foo.active = true
+        motion.resolve(foo.resolution)
+        expect(foo.active).toBe(false)
+        expect(foo.didExpire).toBe(motion.isExpired)
 
+        actions = {
+            passed: [
+              {
+                action: "forward",
+                to: "foo",
+              },
+            ],
+          }
+        foo.active = true
+        motion.council.setConfig("onFinishActions", actions)
+        motion.council.setConfig("onPassedAnnounce", "foo")
+        motion.resolve(foo.resolution)
+        expect(foo.active).toBe(false)
+        expect(foo.didExpire).toBe(motion.isExpired)
+        
         foo.deliberationChannelId = "s"
         motion.council.setConfig("keepTranscripts", true)
         foo.active = true
+        foo.resolution = MotionResolution.Killed
+        motion.resolve(foo.resolution)
+        expect(foo.active).toBe(false)
+        expect(foo.didExpire).toBe(motion.isExpired)
 
-        const actions: OnFinishActions = {
+        foo.active = true
+        //Finish actions for killed
+        actions = {
           killed: [
             {
               action: "forward",
@@ -168,9 +203,9 @@ describe("Test Resolve", () => {
         }
         motion.council.setConfig("onFinishActions", actions)
         motion.council.setConfig("onKilledAnnounce", "foo")
-        motionResolve = MotionResolution.Killed
-        motion.resolve(motionResolve)
+        motion.resolve(foo.resolution)
         expect(foo.active).toBe(false)
+        expect(foo.didExpire).toBe(motion.isExpired)
         expect(foo.deliberationChannelId).toBe("s")
     })
 })

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -135,13 +135,18 @@ describe("Test Resolve", () => {
 
     test("Test actions", () =>{
         foo.active = true
-        motion.council.setConfig("onFinishActions", "forward")
+        motion.council.setConfig("onFinishActions", 
+        {
+            failed: [{action: "forward", atMajority: 1, options: undefined, to: 123}], 
+            passed: false, 
+            killed: false
+        })
         motion.council.setConfig("onFailedAnnounce", "foo")
         var motionResolve = MotionResolution.Failed
         motion.resolve(motionResolve)
 
         foo.active = true
-        motion.council.setConfig("onFinishActions", "forward")
+        motion.council.setConfig("onFinishActions", {failed: false, passed: true, killed: false})
         motion.council.setConfig("onPassedAnnounce", "foo")
         motionResolve = MotionResolution.Passed
         motion.resolve(motionResolve)
@@ -149,7 +154,7 @@ describe("Test Resolve", () => {
         foo.deliberationChannelId = "s"
         motion.council.setConfig("keepTranscripts", true)
         foo.active = true
-        motion.council.setConfig("onFinishActions", "forward")
+        motion.council.setConfig("onFinishActions", {failed: false, passed: false, killed: true})
         motion.council.setConfig("onKilledAnnounce", "foo")
         motionResolve = MotionResolution.Killed
         motion.resolve(motionResolve)
@@ -165,11 +170,78 @@ describe("Test motion votes", () =>{
         const votes = motion.getVotes()
         expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 0})
     })
-    test("Test castVote", () =>{
-        expect(1).toBe(1)
-    })
     test("Test getRemainingVoters", () =>{
-        expect(1).toBe(1)
+        const remainingVoters = motion.getRemainingVoters()
+        //users from the council mock that have not voted
+        const expected = [
+            {
+                "deleted": false, 
+                "displayName": "votum-app",
+                "guildID": 123, 
+                "joinedTimestamp": null, 
+                "lastMessageChannelID": null, 
+                "nickname": null, 
+                "premiumSinceTimestamp": null, 
+                "userID": "votum"
+            },
+            {
+                "deleted": false, 
+                "displayName": "user-foo", 
+                "guildID": 123, 
+                "joinedTimestamp": null, 
+                "lastMessageChannelID": null, 
+                "nickname": null, 
+                "premiumSinceTimestamp": null, 
+                "userID": "foo"
+            },
+            {
+                "deleted": false, 
+                "displayName": "user-bar", 
+                "guildID": 123, 
+                "joinedTimestamp": null, 
+                "lastMessageChannelID": null, 
+                "nickname": null, 
+                "premiumSinceTimestamp": null, 
+                "userID": "bar"
+            }]
+        expect(remainingVoters).toStrictEqual(expected)
     })
+    test("Test castVote", () =>{
+        motion.castVote({
+            authorId: "foo",
+            authorName: "user-foo",
+            state: 1,
+            name: "user-foo",
+            reason: "foo",
+            isDictator: false,
+        })
+        const votes = motion.getVotes()
+        expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 1})
+
+        //same voter same vote
+        motion.castVote({
+            authorId: "foo",
+            authorName: "user-foo",
+            state: 1,
+            name: "user-foo",
+            reason: "foo",
+            isDictator: false,
+        })
+        expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 1})
+
+        //dictator vote
+        foo.active = true
+        motion.castVote({
+            authorId: "foo",
+            authorName: "user-foo",
+            state: 1,
+            name: "user-foo",
+            reason: "foo",
+            isDictator: true,
+        })
+        //shouldnt dictatorVoted == true?
+        expect(votes).toStrictEqual({"abs": 0, "dictatorVoted": false, "no": 0, "toPass": 2, "yes": 1})
+    })
+
 })
 })

--- a/src/Motion.test.ts
+++ b/src/Motion.test.ts
@@ -204,7 +204,7 @@ describe("Test motion votes", () =>{
                 "premiumSinceTimestamp": null, 
                 "userID": "bar"
             }]
-        expect(remainingVoters).toStrictEqual(expected)
+        expect(remainingVoters.toJSON()).toStrictEqual(expected)
     })
     test("Test castVote", () =>{
         motion.castVote({


### PR DESCRIPTION
Motion class test

    -Tests creating a motion and setting it's default attributes;
    -Tests motion majorities;
    -Tests motion resolve and it's cases;
    -Tests votes get (general get and get remaining voters) and vote casting;
    -Doesn't test PostMessage and other functions related to it because posting message could be on another class and will probably change when migrating to slash commands.

